### PR TITLE
Lookup with prefix length

### DIFF
--- a/ext/hive_geoip2/hive_geoip2.c
+++ b/ext/hive_geoip2/hive_geoip2.c
@@ -34,7 +34,7 @@ struct args_parse_data_list {
 
 static VALUE guard_parse_data_list(VALUE arg) {
   struct args_parse_data_list *args = (struct args_parse_data_list *)arg;
-
+  
   parse_data_list(args->data_list, args->ret_obj);
 
   return RUBY_Qnil;
@@ -46,48 +46,48 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
     case MMDB_DATA_TYPE_MAP:
     {
       uint32_t size = data_list->entry_data.data_size;
-
+      
       VALUE val;
-
+      
       VALUE hash = rb_hash_new();
-
+      
       for (data_list = data_list->next; size && data_list; size--) {
         VALUE key = rb_enc_str_new(
           data_list->entry_data.utf8_string,
           data_list->entry_data.data_size,
           rb_utf8_encoding()
         );
-
+        
         data_list = data_list->next;
         data_list = parse_data_list(data_list, &val);
-
+        
         rb_hash_aset(hash, key, val);
-
+        
       }
-
+      
       *ret_obj = hash;
-
+      
       break;
     }
-
+    
     case MMDB_DATA_TYPE_ARRAY:
     {
       uint32_t size = data_list->entry_data.data_size;
-
+      
       VALUE val;
-
+      
       VALUE ary = rb_ary_new();
-
+      
       for (data_list = data_list->next; size && data_list; size--) {
         data_list = parse_data_list(data_list, &val);
         rb_ary_push(ary, val);
       }
-
+      
       *ret_obj = ary;
-
+      
       break;
     }
-
+    
     case MMDB_DATA_TYPE_UTF8_STRING:
     {
       *ret_obj = rb_enc_str_new(
@@ -95,12 +95,12 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
         data_list->entry_data.data_size,
         rb_utf8_encoding()
       );
-
+      
       data_list = data_list->next;
-
+      
       break;
     }
-
+    
     case MMDB_DATA_TYPE_BYTES:
     {
       *ret_obj = rb_enc_str_new(
@@ -108,62 +108,62 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
         data_list->entry_data.data_size,
         rb_ascii8bit_encoding()
       );
-
+      
       data_list = data_list->next;
-
+      
       break;
     }
-
+    
     case MMDB_DATA_TYPE_DOUBLE:
     {
       *ret_obj = rb_float_new(data_list->entry_data.double_value);
-
+      
       data_list = data_list->next;
-
+      
       break;
     }
-
+    
     case MMDB_DATA_TYPE_FLOAT:
     {
       *ret_obj = rb_float_new(data_list->entry_data.float_value);
-
+      
       data_list = data_list->next;
-
+      
       break;
     }
-
+    
     case MMDB_DATA_TYPE_UINT16:
     {
       *ret_obj = UINT2NUM(data_list->entry_data.uint16);
-
+      
       data_list = data_list->next;
-
+      
       break;
     }
-
+    
     case MMDB_DATA_TYPE_UINT32:
     {
       *ret_obj = UINT2NUM(data_list->entry_data.uint32);
-
+      
       data_list = data_list->next;
-
+      
       break;
     }
-
+    
     case MMDB_DATA_TYPE_BOOLEAN:
     {
       *ret_obj = data_list->entry_data.boolean ? Qtrue : Qfalse;
-
+      
       data_list = data_list->next;
-
+      
       break;
     }
-
+    
     case MMDB_DATA_TYPE_UINT64:
     {
       const uint8_t *hex = "0123456789abcdef";
       int i, idx = 0;
-
+      
       size_t size = sizeof(uint64_t);
       char buf[size * 2 + 1];
       uint8_t *data = (uint8_t *)&data_list->entry_data.uint64;
@@ -175,16 +175,16 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
         buf[idx++] = hex[data[i] >> 4];
         buf[idx++] = hex[data[i] & 0x0f];
       }
-
+      
       buf[idx] = '\0';
-
+      
       *ret_obj = rb_cstr2inum(buf, 16);
-
+      
       data_list = data_list->next;
-
+      
       break;
     }
-
+    
     case MMDB_DATA_TYPE_UINT128:
     {
       const uint8_t *hex = "0123456789abcdef";
@@ -193,7 +193,7 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
       size_t size = 16;
       char buf[size * 2 + 1];
       uint8_t *data = data_list->entry_data.uint128;
-
+      
       for (i = 0; i < size; ++i) {
         buf[idx++] = hex[data[i] >> 4];
         buf[idx++] = hex[data[i] & 0x0f];
@@ -202,7 +202,7 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
       size_t size = sizeof(mmdb_uint128_t);
       uint8_t buf[size * 2 + 1];
       uint8_t *data = (uint8_t *)&data_list->entry_data.uint128;
-
+      
 #ifdef WORDS_BIGENDIAN
       for (i = 0; i < size; ++i) {
 #else
@@ -213,35 +213,35 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
       }
 #endif
       buf[idx] = '\0';
-
+      
       *ret_obj = rb_cstr2inum(buf, 16);
-
+      
       data_list = data_list->next;
-
+      
       break;
     }
-
+    
     case MMDB_DATA_TYPE_INT32:
     {
       *ret_obj = INT2NUM(data_list->entry_data.int32);
-
+      
       data_list = data_list->next;
-
+      
       break;
     }
-
+    
     default:
       rb_raise(rb_eRuntimeError,
         "GeoIP2 - %s", MMDB_strerror(MMDB_INVALID_DATA_ERROR)
       );
   }
-
+  
   return data_list;
 }
 
 static void mmdb_try_open(char *db_path, MMDB_s *mmdb) {
   int status = MMDB_open(db_path, MMDB_MODE_MMAP, mmdb);
-
+  
   if (status != MMDB_SUCCESS) {
     rb_raise(rb_eIOError, "GeoIP2 - %s: %s",
       MMDB_strerror(status), db_path
@@ -260,65 +260,65 @@ static inline void mmdb_close(MMDB_s *mmdb) {
 
 static VALUE mmdb_lookup(MMDB_s *mmdb, char *ip_addr, bool cleanup) {
   int status, gai_error, mmdb_error;
-
+  
   MMDB_lookup_result_s result =
     MMDB_lookup_string(mmdb, ip_addr, &gai_error, &mmdb_error);
-
+  
   if (mmdb_error != MMDB_SUCCESS) {
     if (cleanup) {
       mmdb_close(mmdb);
     }
-
+    
     rb_raise(rb_eRuntimeError,
       "GeoIP2 - lookup failed: %s", MMDB_strerror(mmdb_error)
     );
   }
-
+  
   if (gai_error != 0) {
     if (cleanup) {
       mmdb_close(mmdb);
     }
-
+    
     rb_raise(rb_eRuntimeError,
       "GeoIP2 - getaddrinfo failed: %s", gai_strerror(gai_error)
     );
   }
-
+  
   if (result.found_entry) {
     MMDB_entry_data_list_s *data_list, *first;
-
+    
     status = MMDB_get_entry_data_list(&result.entry, &data_list);
-
+    
     if (status != MMDB_SUCCESS) {
       MMDB_free_entry_data_list(data_list);
-
+      
       if (cleanup) {
         mmdb_close(mmdb);
       }
-
+      
       rb_raise(rb_eRuntimeError,
         "GeoIP2 - couldn\'t fetch results: %s", MMDB_strerror(status)
       );
     }
-
+    
     first = data_list;
-
+    
     int exception = 0;
-
+    
     VALUE ret_obj;
-
+    
     struct args_parse_data_list args;
     args.data_list = data_list;
     args.ret_obj = &ret_obj;
-
+    
     rb_protect(guard_parse_data_list, (VALUE)&args, &exception);
-
+    
     MMDB_free_entry_data_list(first);
-
+    
     if (cleanup) {
       mmdb_close(mmdb);
     }
-
+    
     if (exception) {
       rb_jump_tag(exception);
     }
@@ -343,13 +343,13 @@ static VALUE mmdb_lookup(MMDB_s *mmdb, char *ip_addr, bool cleanup) {
 
 static VALUE rb_hive_geo_lookup(VALUE self, VALUE ip_arg) {
   Check_Type(ip_arg, T_STRING);
-
+  
   char *ip_addr = StringValuePtr(ip_arg);
-
+  
   MMDB_s *mmdb;
-
+  
   Data_Get_Struct(self, MMDB_s, mmdb);
-
+  
   if (mmdb_is_closed(mmdb)) {
     rb_raise(rb_eIOError, "GeoIP2 - closed database");
   }
@@ -360,12 +360,12 @@ static VALUE rb_hive_geo_lookup(VALUE self, VALUE ip_arg) {
 static VALUE rb_hive_geo_lookup2(VALUE self, VALUE ip_arg, VALUE db_arg) {
   Check_Type(ip_arg, T_STRING);
   Check_Type(db_arg, T_STRING);
-
+  
   char *ip_addr = StringValuePtr(ip_arg);
   char *db_path = StringValuePtr(db_arg);
-
+  
   MMDB_s mmdb;
-
+  
   mmdb_try_open(db_path, &mmdb);
   VALUE result_tuple = mmdb_lookup(&mmdb, ip_addr, true);
   return rb_ary_entry(result_tuple, 0);  // Extract just the data part
@@ -394,21 +394,21 @@ static VALUE rb_hive_geo_lookup_with_prefix_length2(VALUE self, VALUE ip_arg, VA
 
 static VALUE rb_hive_geo_is_closed(VALUE self) {
   MMDB_s *mmdb;
-
+  
   Data_Get_Struct(self, MMDB_s, mmdb);
-
+  
   return mmdb_is_closed(mmdb) ? Qtrue : Qfalse;
 }
 
 static VALUE rb_hive_geo_close(VALUE self) {
   MMDB_s *mmdb;
-
+  
   Data_Get_Struct(self, MMDB_s, mmdb);
-
+  
   if (!mmdb_is_closed(mmdb)) {
     mmdb_close(mmdb);
   }
-
+  
   return Qnil;
 }
 
@@ -416,36 +416,36 @@ static void rb_hive_geo_free(MMDB_s *mmdb) {
   if (!mmdb_is_closed(mmdb)) {
     mmdb_close(mmdb);
   }
-
+  
   xfree(mmdb);
 }
 
 static VALUE rb_hive_geo_alloc(VALUE self) {
   MMDB_s *mmdb = ALLOC(MMDB_s);
-
+  
   return Data_Wrap_Struct(self, NULL, rb_hive_geo_free, mmdb);
 }
 
 static VALUE rb_hive_geo_init(VALUE self, VALUE db_arg) {
   Check_Type(db_arg, T_STRING);
-
+  
   char *db_path = StringValuePtr(db_arg);
-
+  
   MMDB_s *mmdb;
-
+  
   Data_Get_Struct(self, MMDB_s, mmdb);
-
+  
   mmdb_try_open(db_path, mmdb);
-
+  
   return Qnil;
 }
 
 void Init_hive_geoip2() {
   rb_mHive = rb_define_module("Hive");
   rb_cGeoIP2 = rb_define_class_under(rb_mHive, "GeoIP2", rb_cObject);
-
+  
   rb_define_alloc_func(rb_cGeoIP2, rb_hive_geo_alloc);
-
+  
   rb_define_singleton_method(rb_cGeoIP2, "lookup", rb_hive_geo_lookup2, 2);
   rb_define_singleton_method(rb_cGeoIP2, "lookup_with_prefix_length", rb_hive_geo_lookup_with_prefix_length2, 2);
 

--- a/ext/hive_geoip2/hive_geoip2.c
+++ b/ext/hive_geoip2/hive_geoip2.c
@@ -19,6 +19,8 @@ static VALUE mmdb_lookup(MMDB_s *mmdb, char *ip_addr, bool cleanup);
 
 static VALUE rb_hive_geo_lookup(VALUE self, VALUE ip_arg);
 static VALUE rb_hive_geo_lookup2(VALUE self, VALUE ip_arg, VALUE db_arg);
+static VALUE rb_hive_geo_lookup_with_prefix_length(VALUE self, VALUE ip_arg);
+static VALUE rb_hive_geo_lookup_with_prefix_length2(VALUE self, VALUE ip_arg, VALUE db_arg);
 static VALUE rb_hive_geo_is_closed(VALUE self);
 static VALUE rb_hive_geo_close(VALUE self);
 static void rb_hive_geo_free(MMDB_s *mmdb);
@@ -321,10 +323,21 @@ static VALUE mmdb_lookup(MMDB_s *mmdb, char *ip_addr, bool cleanup) {
       rb_jump_tag(exception);
     }
 
-    return ret_obj;
+    // Return [data, prefix_length] tuple
+    VALUE result_array = rb_ary_new2(2);
+    rb_ary_push(result_array, ret_obj);
+    rb_ary_push(result_array, INT2NUM(result.netmask));
+    return result_array;
   }
   else {
-    return Qnil;
+    if (cleanup) {
+      mmdb_close(mmdb);
+    }
+    // Return [nil, 0] for not found
+    VALUE result_array = rb_ary_new2(2);
+    rb_ary_push(result_array, Qnil);
+    rb_ary_push(result_array, INT2NUM(0));
+    return result_array;
   }
 }
 
@@ -340,8 +353,8 @@ static VALUE rb_hive_geo_lookup(VALUE self, VALUE ip_arg) {
   if (mmdb_is_closed(mmdb)) {
     rb_raise(rb_eIOError, "GeoIP2 - closed database");
   }
-
-  return mmdb_lookup(mmdb, ip_addr, false);
+  VALUE result_tuple = mmdb_lookup(mmdb, ip_addr, false);
+  return rb_ary_entry(result_tuple, 0);  // Extract just the data part
 }
 
 static VALUE rb_hive_geo_lookup2(VALUE self, VALUE ip_arg, VALUE db_arg) {
@@ -354,8 +367,29 @@ static VALUE rb_hive_geo_lookup2(VALUE self, VALUE ip_arg, VALUE db_arg) {
   MMDB_s mmdb;
 
   mmdb_try_open(db_path, &mmdb);
+  VALUE result_tuple = mmdb_lookup(&mmdb, ip_addr, true);
+  return rb_ary_entry(result_tuple, 0);  // Extract just the data part
+}
 
-  return mmdb_lookup(&mmdb, ip_addr, true);
+static VALUE rb_hive_geo_lookup_with_prefix_length(VALUE self, VALUE ip_arg) {
+  Check_Type(ip_arg, T_STRING);
+  char *ip_addr = StringValuePtr(ip_arg);
+  MMDB_s *mmdb;
+  Data_Get_Struct(self, MMDB_s, mmdb);
+  if (mmdb_is_closed(mmdb)) {
+    rb_raise(rb_eIOError, "GeoIP2 - closed database");
+  }
+  return mmdb_lookup(mmdb, ip_addr, false); // Return full tuple with prefix length
+}
+
+static VALUE rb_hive_geo_lookup_with_prefix_length2(VALUE self, VALUE ip_arg, VALUE db_arg) {
+  Check_Type(ip_arg, T_STRING);
+  Check_Type(db_arg, T_STRING);
+  char *ip_addr = StringValuePtr(ip_arg);
+  char *db_path = StringValuePtr(db_arg);
+  MMDB_s mmdb;
+  mmdb_try_open(db_path, &mmdb);
+  return mmdb_lookup(&mmdb, ip_addr, true);  // Return full tuple with prefix length
 }
 
 static VALUE rb_hive_geo_is_closed(VALUE self) {
@@ -413,9 +447,11 @@ void Init_hive_geoip2() {
   rb_define_alloc_func(rb_cGeoIP2, rb_hive_geo_alloc);
 
   rb_define_singleton_method(rb_cGeoIP2, "lookup", rb_hive_geo_lookup2, 2);
+  rb_define_singleton_method(rb_cGeoIP2, "lookup_with_prefix_length", rb_hive_geo_lookup_with_prefix_length2, 2);
 
   rb_define_method(rb_cGeoIP2, "initialize", rb_hive_geo_init, 1);
   rb_define_method(rb_cGeoIP2, "close", rb_hive_geo_close, 0);
   rb_define_method(rb_cGeoIP2, "closed?", rb_hive_geo_is_closed, 0);
   rb_define_method(rb_cGeoIP2, "lookup", rb_hive_geo_lookup, 1);
+  rb_define_method(rb_cGeoIP2, "lookup_with_prefix_length", rb_hive_geo_lookup_with_prefix_length, 1);
 }

--- a/ext/hive_geoip2/hive_geoip2.c
+++ b/ext/hive_geoip2/hive_geoip2.c
@@ -32,7 +32,7 @@ struct args_parse_data_list {
 
 static VALUE guard_parse_data_list(VALUE arg) {
   struct args_parse_data_list *args = (struct args_parse_data_list *)arg;
-  
+
   parse_data_list(args->data_list, args->ret_obj);
 
   return RUBY_Qnil;
@@ -44,48 +44,48 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
     case MMDB_DATA_TYPE_MAP:
     {
       uint32_t size = data_list->entry_data.data_size;
-      
+
       VALUE val;
-      
+
       VALUE hash = rb_hash_new();
-      
+
       for (data_list = data_list->next; size && data_list; size--) {
         VALUE key = rb_enc_str_new(
           data_list->entry_data.utf8_string,
           data_list->entry_data.data_size,
           rb_utf8_encoding()
         );
-        
+
         data_list = data_list->next;
         data_list = parse_data_list(data_list, &val);
-        
+
         rb_hash_aset(hash, key, val);
-        
+
       }
-      
+
       *ret_obj = hash;
-      
+
       break;
     }
-    
+
     case MMDB_DATA_TYPE_ARRAY:
     {
       uint32_t size = data_list->entry_data.data_size;
-      
+
       VALUE val;
-      
+
       VALUE ary = rb_ary_new();
-      
+
       for (data_list = data_list->next; size && data_list; size--) {
         data_list = parse_data_list(data_list, &val);
         rb_ary_push(ary, val);
       }
-      
+
       *ret_obj = ary;
-      
+
       break;
     }
-    
+
     case MMDB_DATA_TYPE_UTF8_STRING:
     {
       *ret_obj = rb_enc_str_new(
@@ -93,12 +93,12 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
         data_list->entry_data.data_size,
         rb_utf8_encoding()
       );
-      
+
       data_list = data_list->next;
-      
+
       break;
     }
-    
+
     case MMDB_DATA_TYPE_BYTES:
     {
       *ret_obj = rb_enc_str_new(
@@ -106,62 +106,62 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
         data_list->entry_data.data_size,
         rb_ascii8bit_encoding()
       );
-      
+
       data_list = data_list->next;
-      
+
       break;
     }
-    
+
     case MMDB_DATA_TYPE_DOUBLE:
     {
       *ret_obj = rb_float_new(data_list->entry_data.double_value);
-      
+
       data_list = data_list->next;
-      
+
       break;
     }
-    
+
     case MMDB_DATA_TYPE_FLOAT:
     {
       *ret_obj = rb_float_new(data_list->entry_data.float_value);
-      
+
       data_list = data_list->next;
-      
+
       break;
     }
-    
+
     case MMDB_DATA_TYPE_UINT16:
     {
       *ret_obj = UINT2NUM(data_list->entry_data.uint16);
-      
+
       data_list = data_list->next;
-      
+
       break;
     }
-    
+
     case MMDB_DATA_TYPE_UINT32:
     {
       *ret_obj = UINT2NUM(data_list->entry_data.uint32);
-      
+
       data_list = data_list->next;
-      
+
       break;
     }
-    
+
     case MMDB_DATA_TYPE_BOOLEAN:
     {
       *ret_obj = data_list->entry_data.boolean ? Qtrue : Qfalse;
-      
+
       data_list = data_list->next;
-      
+
       break;
     }
-    
+
     case MMDB_DATA_TYPE_UINT64:
     {
       const uint8_t *hex = "0123456789abcdef";
       int i, idx = 0;
-      
+
       size_t size = sizeof(uint64_t);
       char buf[size * 2 + 1];
       uint8_t *data = (uint8_t *)&data_list->entry_data.uint64;
@@ -173,16 +173,16 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
         buf[idx++] = hex[data[i] >> 4];
         buf[idx++] = hex[data[i] & 0x0f];
       }
-      
+
       buf[idx] = '\0';
-      
+
       *ret_obj = rb_cstr2inum(buf, 16);
-      
+
       data_list = data_list->next;
-      
+
       break;
     }
-    
+
     case MMDB_DATA_TYPE_UINT128:
     {
       const uint8_t *hex = "0123456789abcdef";
@@ -191,7 +191,7 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
       size_t size = 16;
       char buf[size * 2 + 1];
       uint8_t *data = data_list->entry_data.uint128;
-      
+
       for (i = 0; i < size; ++i) {
         buf[idx++] = hex[data[i] >> 4];
         buf[idx++] = hex[data[i] & 0x0f];
@@ -200,7 +200,7 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
       size_t size = sizeof(mmdb_uint128_t);
       uint8_t buf[size * 2 + 1];
       uint8_t *data = (uint8_t *)&data_list->entry_data.uint128;
-      
+
 #ifdef WORDS_BIGENDIAN
       for (i = 0; i < size; ++i) {
 #else
@@ -211,35 +211,35 @@ parse_data_list(MMDB_entry_data_list_s *data_list, VALUE *ret_obj) {
       }
 #endif
       buf[idx] = '\0';
-      
+
       *ret_obj = rb_cstr2inum(buf, 16);
-      
+
       data_list = data_list->next;
-      
+
       break;
     }
-    
+
     case MMDB_DATA_TYPE_INT32:
     {
       *ret_obj = INT2NUM(data_list->entry_data.int32);
-      
+
       data_list = data_list->next;
-      
+
       break;
     }
-    
+
     default:
       rb_raise(rb_eRuntimeError,
         "GeoIP2 - %s", MMDB_strerror(MMDB_INVALID_DATA_ERROR)
       );
   }
-  
+
   return data_list;
 }
 
 static void mmdb_try_open(char *db_path, MMDB_s *mmdb) {
   int status = MMDB_open(db_path, MMDB_MODE_MMAP, mmdb);
-  
+
   if (status != MMDB_SUCCESS) {
     rb_raise(rb_eIOError, "GeoIP2 - %s: %s",
       MMDB_strerror(status), db_path
@@ -258,69 +258,69 @@ static inline void mmdb_close(MMDB_s *mmdb) {
 
 static VALUE mmdb_lookup(MMDB_s *mmdb, char *ip_addr, bool cleanup) {
   int status, gai_error, mmdb_error;
-  
+
   MMDB_lookup_result_s result =
     MMDB_lookup_string(mmdb, ip_addr, &gai_error, &mmdb_error);
-  
+
   if (mmdb_error != MMDB_SUCCESS) {
     if (cleanup) {
       mmdb_close(mmdb);
     }
-    
+
     rb_raise(rb_eRuntimeError,
       "GeoIP2 - lookup failed: %s", MMDB_strerror(mmdb_error)
     );
   }
-  
+
   if (gai_error != 0) {
     if (cleanup) {
       mmdb_close(mmdb);
     }
-    
+
     rb_raise(rb_eRuntimeError,
       "GeoIP2 - getaddrinfo failed: %s", gai_strerror(gai_error)
     );
   }
-  
+
   if (result.found_entry) {
     MMDB_entry_data_list_s *data_list, *first;
-    
+
     status = MMDB_get_entry_data_list(&result.entry, &data_list);
-    
+
     if (status != MMDB_SUCCESS) {
       MMDB_free_entry_data_list(data_list);
-      
+
       if (cleanup) {
         mmdb_close(mmdb);
       }
-      
+
       rb_raise(rb_eRuntimeError,
         "GeoIP2 - couldn\'t fetch results: %s", MMDB_strerror(status)
       );
     }
-    
+
     first = data_list;
-    
+
     int exception = 0;
-    
+
     VALUE ret_obj;
-    
+
     struct args_parse_data_list args;
     args.data_list = data_list;
     args.ret_obj = &ret_obj;
-    
+
     rb_protect(guard_parse_data_list, (VALUE)&args, &exception);
-    
+
     MMDB_free_entry_data_list(first);
-    
+
     if (cleanup) {
       mmdb_close(mmdb);
     }
-    
+
     if (exception) {
       rb_jump_tag(exception);
     }
-    
+
     return ret_obj;
   }
   else {
@@ -330,51 +330,51 @@ static VALUE mmdb_lookup(MMDB_s *mmdb, char *ip_addr, bool cleanup) {
 
 static VALUE rb_hive_geo_lookup(VALUE self, VALUE ip_arg) {
   Check_Type(ip_arg, T_STRING);
-  
+
   char *ip_addr = StringValuePtr(ip_arg);
-  
+
   MMDB_s *mmdb;
-  
+
   Data_Get_Struct(self, MMDB_s, mmdb);
-  
+
   if (mmdb_is_closed(mmdb)) {
     rb_raise(rb_eIOError, "GeoIP2 - closed database");
   }
-  
+
   return mmdb_lookup(mmdb, ip_addr, false);
 }
 
 static VALUE rb_hive_geo_lookup2(VALUE self, VALUE ip_arg, VALUE db_arg) {
   Check_Type(ip_arg, T_STRING);
   Check_Type(db_arg, T_STRING);
-  
+
   char *ip_addr = StringValuePtr(ip_arg);
   char *db_path = StringValuePtr(db_arg);
-  
+
   MMDB_s mmdb;
-  
+
   mmdb_try_open(db_path, &mmdb);
-  
+
   return mmdb_lookup(&mmdb, ip_addr, true);
 }
 
 static VALUE rb_hive_geo_is_closed(VALUE self) {
   MMDB_s *mmdb;
-  
+
   Data_Get_Struct(self, MMDB_s, mmdb);
-  
+
   return mmdb_is_closed(mmdb) ? Qtrue : Qfalse;
 }
 
 static VALUE rb_hive_geo_close(VALUE self) {
   MMDB_s *mmdb;
-  
+
   Data_Get_Struct(self, MMDB_s, mmdb);
-  
+
   if (!mmdb_is_closed(mmdb)) {
     mmdb_close(mmdb);
   }
-  
+
   return Qnil;
 }
 
@@ -382,38 +382,38 @@ static void rb_hive_geo_free(MMDB_s *mmdb) {
   if (!mmdb_is_closed(mmdb)) {
     mmdb_close(mmdb);
   }
-  
+
   xfree(mmdb);
 }
 
 static VALUE rb_hive_geo_alloc(VALUE self) {
   MMDB_s *mmdb = ALLOC(MMDB_s);
-  
+
   return Data_Wrap_Struct(self, NULL, rb_hive_geo_free, mmdb);
 }
 
 static VALUE rb_hive_geo_init(VALUE self, VALUE db_arg) {
   Check_Type(db_arg, T_STRING);
-  
+
   char *db_path = StringValuePtr(db_arg);
-  
+
   MMDB_s *mmdb;
-  
+
   Data_Get_Struct(self, MMDB_s, mmdb);
-  
+
   mmdb_try_open(db_path, mmdb);
-  
+
   return Qnil;
 }
 
 void Init_hive_geoip2() {
   rb_mHive = rb_define_module("Hive");
   rb_cGeoIP2 = rb_define_class_under(rb_mHive, "GeoIP2", rb_cObject);
-  
+
   rb_define_alloc_func(rb_cGeoIP2, rb_hive_geo_alloc);
-  
+
   rb_define_singleton_method(rb_cGeoIP2, "lookup", rb_hive_geo_lookup2, 2);
-  
+
   rb_define_method(rb_cGeoIP2, "initialize", rb_hive_geo_init, 1);
   rb_define_method(rb_cGeoIP2, "close", rb_hive_geo_close, 0);
   rb_define_method(rb_cGeoIP2, "closed?", rb_hive_geo_is_closed, 0);


### PR DESCRIPTION
Add another method (both Class and Instance) `lookup_with_prefix_length`, that returns an array that includes IP data as well as `result.netmask`. This is useful because it allows computation of the larges CIDR (or network) which has the same values as the looked up IP.

The name is inspired by `mmdb-lib` with their method `getWithPrefixLength`
